### PR TITLE
PE: add Authenticode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ Check `--help` for more options (_JSON output_, _recursive walk_, _workers count
 | Output JSON                 |     ✔       |    ✔        |
 | PE: ASLR - DYNAMIC_BASE     |     ✔       |    ✔        |
 | PE: ASLR - HIGHENTROPYVA    |     ✔       |    ✔        |
-| PE: INTEGRITYCHECK          |     ❌       |    ✔        |
-| PE: Authenticode signed     |     ❌      |    ✔        |
+| PE: INTEGRITYCHECK          |     ❌      |    ✔        |
+| PE: Authenticode signed     |     ✔       |    ✔        |
 | PE: DEP                     |     ✔       |   ✔         |
 | PE: Manifest Isolation      |     ✔       |    ✔        |
 | PE: SEH                     |     ✔       |    ✔        |

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Checksec tool in Python, Rich output, based on LIEF
   </a>
 </p>
 <p align="center">
-  <a href="">
-    <img src="https://img.shields.io/pypi/dm/checksec.py?color=blue&label=PyPI%20downloads&style=flat-square" />
+  <a href="https://pepy.tech/project/checksec.py">
+    <img src="https://pepy.tech/badge/checksec-py" />  
   </a>
-  <a href="https://github.com/Wenzel/checksec.py/releases">
-    <img src="https://img.shields.io/github/downloads/Wenzel/checksec.py/total?color=blue&label=Github%20downloads&style=flat-square" />
+  <a href="https://pepy.tech/project/checksec.py">
+    <img src="https://img.shields.io/pypi/dm/checksec.py?color=blue&label=downloads&style=flat-square" />
   </a>
 </p>
 

--- a/checksec/__main__.py
+++ b/checksec/__main__.py
@@ -18,6 +18,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 from typing import Iterator, List, Optional, Union
 
+import lief  # only to set the lief logging level
 from docopt import docopt
 
 from .elf import ELFChecksecData, ELFSecurity, get_libc, is_elf
@@ -75,9 +76,12 @@ def main(args):
     # logging
     formatter = "%(asctime)s %(levelname)s:%(name)s:%(message)s"
     log_lvl = logging.INFO
+    lief_logging = lief.logging.LOGGING_LEVEL.CRITICAL  # silence lief warnings
     if debug:
         log_lvl = logging.DEBUG
+        lief_logging = lief.logging.LOGGING_LEVEL.DEBUG
     logging.basicConfig(level=log_lvl, format=formatter)
+    lief.logging.set_level(lief_logging)
 
     libc_detected = False
     # init Libc LIEF object

--- a/checksec/output.py
+++ b/checksec/output.py
@@ -84,6 +84,7 @@ class RichOutput(AbstractChecksecOutput):
         self.table_pe.add_column("Force Integrity", justify="center")
         self.table_pe.add_column("Control Flow Guard", justify="center")
         self.table_pe.add_column("Isolation", justify="center")
+        self.table_pe.add_column("Authenticode", justify="center")
 
         # init console
         self.console = Console()
@@ -265,6 +266,11 @@ class RichOutput(AbstractChecksecOutput):
             else:
                 safe_seh_res = "/"
 
+            if not checksec.authenticode:
+                auth_res = "[red]No"
+            else:
+                auth_res = "[green]Yes"
+
             if not checksec.force_integrity:
                 force_integrity_res = "[red]No"
             else:
@@ -292,6 +298,7 @@ class RichOutput(AbstractChecksecOutput):
                 force_integrity_res,
                 guard_cf_res,
                 isolation_res,
+                auth_res,
             )
         else:
             raise NotImplementedError
@@ -349,6 +356,7 @@ class JSONOutput(AbstractChecksecOutput):
                 "isolation": checksec.isolation,
                 "seh": checksec.seh,
                 "safe_seh": checksec.safe_seh,
+                "authenticode": checksec.authenticode,
                 "guard_cf": checksec.guard_cf,
                 "force_integrity": checksec.force_integrity,
             }

--- a/checksec/pe.py
+++ b/checksec/pe.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from pathlib import Path
 
 import lief
-from lief.PE import DLL_CHARACTERISTICS, HEADER_CHARACTERISTICS, MACHINE_TYPES
+from lief.PE import DLL_CHARACTERISTICS, HEADER_CHARACTERISTICS, MACHINE_TYPES, Signature
 
 from .binary import BinarySecurity
 
@@ -20,6 +20,7 @@ PEChecksecData = namedtuple(
         "force_integrity",
         "guard_cf",
         "isolation",
+        "authenticode",
     ],
 )
 
@@ -89,6 +90,11 @@ class PESecurity(BinarySecurity):
             return False
 
     @property
+    def is_authenticode_valid(self) -> bool:
+        """Whether the binary has a valid Authenticode signature"""
+        return self.bin.verify_signature() == Signature.VERIFICATION_FLAGS.OK
+
+    @property
     def has_force_integrity(self) -> bool:
         """Whether FORCE_INTEGRITY is enabled"""
         # 2011 ?
@@ -127,4 +133,5 @@ class PESecurity(BinarySecurity):
             force_integrity=self.has_force_integrity,
             guard_cf=self.has_guard_cf,
             isolation=self.has_isolation,
+            authenticode=self.is_authenticode_valid,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lief==0.10.1
+lief==0.11.0
 docopt==0.6.2
 rich==7.1.0
 pylddwrap==1.0.1

--- a/tests/e2e/test_e2e_pe.py
+++ b/tests/e2e/test_e2e_pe.py
@@ -22,6 +22,7 @@ PE_BINARIES = Path(__file__).parent.parent / "binaries" / "pe"
         "force_integrity",
         "guard_cf",
         "isolation",
+        "authenticode",
     ],
 )
 def test_bool_prop(prop: str, is_enabled: bool):


### PR DESCRIPTION
- upgrade LIEF to `0.11.0`
- PE: add authenticode signature support

fix #98 
help fix https://github.com/Wenzel/checksec.py/issues/28