### PR TITLE
Fix relro detection

### DIFF
--- a/checksec/elf.py
+++ b/checksec/elf.py
@@ -118,12 +118,23 @@ class ELFSecurity(BinarySecurity):
     def relro(self) -> RelroType:
         try:
             self.bin.get(lief.ELF.SEGMENT_TYPES.GNU_RELRO)
-            if lief.ELF.DYNAMIC_FLAGS.BIND_NOW in self.bin.get(lief.ELF.DYNAMIC_TAGS.FLAGS):
-                return RelroType.Full
-            else:
-                return RelroType.Partial
         except lief.not_found:
             return RelroType.No
+
+        try:
+            bind_now = lief.ELF.DYNAMIC_FLAGS.BIND_NOW in self.bin.get(lief.ELF.DYNAMIC_TAGS.FLAGS)
+        except lief.not_found:
+            bind_now = False
+
+        try:
+            now = lief.ELF.DYNAMIC_FLAGS_1.NOW in self.bin.get(lief.ELF.DYNAMIC_TAGS.FLAGS_1)
+        except lief.not_found:
+            now = False
+
+        if bind_now or now:
+            return RelroType.Full
+        else:
+            return RelroType.Partial
 
     @property
     def has_canary(self) -> bool:

--- a/tests/e2e/test_e2e_elf.py
+++ b/tests/e2e/test_e2e_elf.py
@@ -28,6 +28,13 @@ def test_relro(relro_type: RelroType):
     assert chk_data[str(bin_path)]["relro"] == relro_type.name
 
 
+def test_relro_full_df1():
+    """Test that relro type is full via dynamic flags 1"""
+    bin_path = ELF_BINARIES / "relro_full_FLAGS_1"
+    chk_data = run_checksec(bin_path)
+    assert chk_data[str(bin_path)]["relro"] == RelroType.Full.name
+
+
 @pytest.mark.parametrize("pie_type", list(PIEType))
 def test_pie(pie_type):
     """Test that PIE is No/Partial/Full"""


### PR DESCRIPTION
Currently, relro is only detected when the BIND_NOW is set. If however
the NOW flag in the FLAGS_1 section is set, relro is not detected (it
does not even tell that relro is enabled partially). With this commit
relro is detected correctly.

Issue link: https://github.com/Wenzel/checksec.py/issues/105