### PR TITLE
fortify source check: Treat binaries with 0 fortifiable as fortified

### DIFF
--- a/checksec/elf.py
+++ b/checksec/elf.py
@@ -229,8 +229,7 @@ class ELFSecurity(BinarySecurity):
                 else:
                     score = (fortified_count * 100) / fortifiable_count
                     score = round(score)
-
-            fortify_source = True if fortified_count != 0 else False
+            fortify_source = True if fortified_count != 0 or fortifiable_count == 0 else False
         return ELFChecksecData(
             relro=self.relro,
             canary=self.has_canary,


### PR DESCRIPTION
Hi,

a suggestion from my side: Lets treat binaries that have no instance of a not fortified piece of code as fortified because there is no evidence that it is not fortified and there is no risk since there is no place that could have been protected by the compiler. What do you think?
