### PR TITLE
ELF: add support for PIEType REL

### DIFF
--- a/checksec/elf.py
+++ b/checksec/elf.py
@@ -77,6 +77,7 @@ class PIEType(Enum):
     No = 1
     DSO = 2
     PIE = 3
+    REL = 4
 
 
 class Libc:
@@ -155,6 +156,8 @@ class ELFSecurity(BinarySecurity):
                 return PIEType.PIE
             else:
                 return PIEType.DSO
+        elif self.bin.header.file_type == E_TYPE.RELOCATABLE:
+            return PIEType.REL
         return PIEType.No
 
     @property

--- a/checksec/elf.py
+++ b/checksec/elf.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import FrozenSet, List, Optional
 
 import lief
+from lief.ELF import E_TYPE
 
 from .binary import BinarySecurity
 from .errors import ErrorParsingFailed
@@ -149,7 +150,7 @@ class ELFSecurity(BinarySecurity):
 
     @property
     def pie(self) -> PIEType:
-        if self.bin.is_pie:
+        if self.bin.header.file_type == E_TYPE.DYNAMIC:
             if self.bin.has(lief.ELF.DYNAMIC_TAGS.DEBUG):
                 return PIEType.PIE
             else:

--- a/checksec/output.py
+++ b/checksec/output.py
@@ -154,6 +154,8 @@ class RichOutput(AbstractChecksecOutput):
                 pie_res = f"[red]{pie.name}"
             elif pie == PIEType.DSO:
                 pie_res = f"[yellow]{pie.name}"
+            elif pie == PIEType.REL:
+                pie_res = f"[yellow]{pie.name}"
             else:
                 pie_res = "[green]Yes"
             row_res.append(pie_res)


### PR DESCRIPTION
This PR adds support for another PIE type: `REL`, relocatable ELFs.

solves #110 