### PR TITLE
Fix building package with venv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-lief==0.11.0
-docopt==0.6.2
-rich==7.1.0
-pylddwrap==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,6 @@ import setuptools
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
-
 setuptools.setup(
     name="checksec.py",
     version="0.6.2",
@@ -16,7 +13,12 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/Wenzel/checksec.py",
     packages=setuptools.find_packages(),
-    install_requires=requirements,
+    install_requires=[
+        "lief==0.11.0",
+        "docopt==0.6.2",
+        "rich==7.1.0",
+        "pylddwrap==1.0.1",
+    ],
     entry_points={
         "console_scripts": ["checksec = checksec.__main__:entrypoint"],
     },


### PR DESCRIPTION
Hi
I tried creating a package on my system and found that the build process fails:
```
* Creating venv isolated environment...
* Installing packages in isolated environment... (setuptools >= 40.8.0, wheel)
* Getting dependencies for sdist...
running egg_info
writing checksec.py.egg-info/PKG-INFO
writing dependency_links to checksec.py.egg-info/dependency_links.txt
writing entry points to checksec.py.egg-info/entry_points.txt
writing requirements to checksec.py.egg-info/requires.txt
writing top-level names to checksec.py.egg-info/top_level.txt
reading manifest file 'checksec.py.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'checksec.py.egg-info/SOURCES.txt'
* Building sdist...
running sdist
running egg_info
writing checksec.py.egg-info/PKG-INFO
writing dependency_links to checksec.py.egg-info/dependency_links.txt
writing entry points to checksec.py.egg-info/entry_points.txt
writing requirements to checksec.py.egg-info/requires.txt
writing top-level names to checksec.py.egg-info/top_level.txt
reading manifest file 'checksec.py.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'checksec.py.egg-info/SOURCES.txt'
running check
creating checksec.py-0.6.2
creating checksec.py-0.6.2/checksec
creating checksec.py-0.6.2/checksec.py.egg-info
copying files to checksec.py-0.6.2...
copying LICENSE -> checksec.py-0.6.2
copying README.md -> checksec.py-0.6.2
copying setup.cfg -> checksec.py-0.6.2
copying setup.py -> checksec.py-0.6.2
copying checksec/__init__.py -> checksec.py-0.6.2/checksec
copying checksec/__main__.py -> checksec.py-0.6.2/checksec
copying checksec/binary.py -> checksec.py-0.6.2/checksec
copying checksec/elf.py -> checksec.py-0.6.2/checksec
copying checksec/errors.py -> checksec.py-0.6.2/checksec
copying checksec/output.py -> checksec.py-0.6.2/checksec
copying checksec/pe.py -> checksec.py-0.6.2/checksec
copying checksec/utils.py -> checksec.py-0.6.2/checksec
copying checksec.py.egg-info/PKG-INFO -> checksec.py-0.6.2/checksec.py.egg-info
copying checksec.py.egg-info/SOURCES.txt -> checksec.py-0.6.2/checksec.py.egg-info
copying checksec.py.egg-info/dependency_links.txt -> checksec.py-0.6.2/checksec.py.egg-info
copying checksec.py.egg-info/entry_points.txt -> checksec.py-0.6.2/checksec.py.egg-info
copying checksec.py.egg-info/requires.txt -> checksec.py-0.6.2/checksec.py.egg-info
copying checksec.py.egg-info/top_level.txt -> checksec.py-0.6.2/checksec.py.egg-info
Writing checksec.py-0.6.2/setup.cfg
Creating tar archive
removing 'checksec.py-0.6.2' (and everything under it)
* Building wheel from sdist
* Creating venv isolated environment...
* Installing packages in isolated environment... (setuptools >= 40.8.0, wheel)
* Getting dependencies for wheel...
Traceback (most recent call last):
  File "/home/rogier.stam/.local/lib/python3.6/site-packages/pep517/in_process/_in_process.py", line 363, in <module>
    main()
  File "/home/rogier.stam/.local/lib/python3.6/site-packages/pep517/in_process/_in_process.py", line 345, in main
    json_out['return_val'] = hook(**hook_input['kwargs'])
  File "/home/rogier.stam/.local/lib/python3.6/site-packages/pep517/in_process/_in_process.py", line 130, in get_requires_for_build_wheel
    return hook(config_settings)
  File "/tmp/build-env-d83ikglo/lib/python3.6/site-packages/setuptools/build_meta.py", line 155, in get_requires_for_build_wheel
    config_settings, requirements=['wheel'])
  File "/tmp/build-env-d83ikglo/lib/python3.6/site-packages/setuptools/build_meta.py", line 135, in _get_build_requires
    self.run_setup()
  File "/tmp/build-env-d83ikglo/lib/python3.6/site-packages/setuptools/build_meta.py", line 259, in run_setup
    self).run_setup(setup_script=setup_script)
  File "/tmp/build-env-d83ikglo/lib/python3.6/site-packages/setuptools/build_meta.py", line 150, in run_setup
    exec(compile(code, __file__, 'exec'), locals())
  File "setup.py", line 6, in <module>
    with open("requirements.txt") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'

ERROR Backend subproccess exited when trying to invoke get_requires_for_build_wheel
```
This is caused by requirements.txt not being part of the package. Adding it to the package caused problems when installing as it appears one directory lower than the package directory (checksec). To fix this I moved the requirements into the setup.py.

Hope this is considered to be merged.

Thanks

Rogier