### PR TITLE
Fix typo "checkec" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ source venv/bin/activate
 ## Usage
 
 ~~~
-(venv) checkec <file_or_directory>...
+(venv) checksec <file_or_directory>...
 ~~~
 
 Check `--help` for more options (_JSON output_, _recursive walk_, _workers count_)


### PR DESCRIPTION
README.md tells us to call "checksec" using "checkec" (missing "s").  
This can be confusing at first to the user.  
This pull request fixes the issue.