### PR TITLE
pyproject.toml: drop python < 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["checksec", "security", "ELF", "PE", "binary"]
 checksec = 'checksec.__main__:entrypoint'
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10"
 lief = "0.15.1"
 docopt = "0.6.2"
 rich = "^13.4"


### PR DESCRIPTION
checksec works perfectly fine with python 3.13 so drop python < 3.13 from pyproject.toml