### PR TITLE
CI: rework caching and build/test environment

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Poetry
-        run: |
+      run: |
           pipx install poetry==2.1.3
     - name: Set up Python 🐍
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -13,41 +13,42 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install Poetry
-      run: pipx install poetry==${{ inputs.poetry_version }}
-      shell: bash
+  - name: Install Poetry
+    run: pipx install poetry==${{ inputs.poetry_version }}
+    shell: bash
 
-    - name: Set up Python 🐍
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-      with:
-        python-version: ${{ inputs.python_version }}
-        cache: poetry
-        cache-dependency-path: poetry.lock
+  - name: Set up Python 🐍
+    id: setup-python
+    uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+    with:
+      python-version: ${{ inputs.python_version }}
+      cache: poetry
+      cache-dependency-path: poetry.lock
 
-    - name: Set Poetry environment
-      run: poetry env use ${{ inputs.python_version }}
-      shell: bash
+  - name: Set Poetry environment
+    run: poetry env use ${{ inputs.python_version }}
+    shell: bash
 
-    - name: Default shell
-      run: |
-        if [ "$RUNNER_OS" == "Linux" ]; then
-              echo shellos=bash >> $GITHUB_ENV
-        elif [ "$RUNNER_OS" == "Windows" ]; then
-              echo shellos=powershell >> $GITHUB_ENV
-        else
-              echo "$RUNNER_OS not supported"
-              exit 1
-        fi
-      shell: bash
-    
-    # Install dependencies. `--no-root` means "install all dependencies but not the project
-    # itself", which is what you want to avoid caching _your_ code. The `if` statement
-    # ensures this only runs on a cache miss.
-    - name: Install dependencies
-      run: poetry install --no-interaction --no-root
-      shell: ${{ env.shellos }}
-      if: steps.cache-deps.outputs.cache-hit != 'true'
+  - name: Default shell
+    run: |
+      if [ "$RUNNER_OS" == "Linux" ]; then
+            echo shellos=bash >> $GITHUB_ENV
+      elif [ "$RUNNER_OS" == "Windows" ]; then
+            echo shellos=powershell >> $GITHUB_ENV
+      else
+            echo "$RUNNER_OS not supported"
+            exit 1
+      fi
+    shell: bash
 
-    - name: Install project
-      run: poetry install --no-interaction
-      shell: ${{ env.shellos }}
+  # Install dependencies. `--no-root` means "install all dependencies but not the project
+  # itself", which is what you want to avoid caching _your_ code. The `if` statement
+  # ensures this only runs on a cache miss.
+  - name: Install dependencies
+    run: poetry install --no-interaction --no-root
+    shell: ${{ env.shellos }}
+    if: steps.setup-python.outputs.cache-hit != 'true'
+
+  - name: Install project
+    run: poetry install --no-interaction
+    shell: ${{ env.shellos }}

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -12,6 +12,7 @@ runs:
     - name: Install Poetry
       run: |
           pipx install poetry==2.1.3
+      shell: bash
     - name: Set up Python 🐍
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -9,6 +9,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Install Poetry
+        run: |
+          pipx install poetry==2.1.3
     - name: Set up Python 🐍
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
@@ -26,11 +29,6 @@ runs:
               exit 1
         fi
       shell: bash
-
-    - name: Install Poetry
-      uses: abatilo/actions-poetry@65c61eae400c65c9510a584af85138c1ae19bbc0 # v3.0.2
-      with:
-        poetry-version: 2.1.3
     
     # Install dependencies. `--no-root` means "install all dependencies but not the project
     # itself", which is what you want to avoid caching _your_ code. The `if` statement

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -13,6 +13,7 @@ runs:
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ inputs.python_version }}
+        cache: poetry
 
     - name: Default shell
       run: |
@@ -30,17 +31,7 @@ runs:
       uses: abatilo/actions-poetry@65c61eae400c65c9510a584af85138c1ae19bbc0 # v3.0.2
       with:
         poetry-version: 2.1.3
-
-    # Cache your dependencies (i.e. all the stuff in your `pyproject.toml`). Note the cache
-    # key: if you're using multiple Python versions, or multiple OSes, you'd need to include
-    # them in the cache key. I'm not, so it can be simple and just depend on the poetry.lock.
-    - name: cache deps
-      id: cache-deps
-      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-      with:
-        path: ~/.cache/pypoetry
-        key: pydeps-${{ inputs.python_version }}-${{ env.shellos }}-${{ hashFiles('**/poetry.lock') }}
-
+    
     # Install dependencies. `--no-root` means "install all dependencies but not the project
     # itself", which is what you want to avoid caching _your_ code. The `if` statement
     # ensures this only runs on a cache miss.

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -6,18 +6,27 @@ inputs:
     description: "Python version to setup"
     required: true
     default: "3.13"
+  poetry_version:
+    description: "Poetry version to setup"
+    required: true
+    default: "2.1.3"
 runs:
   using: "composite"
   steps:
     - name: Install Poetry
-      run: |
-          pipx install poetry==2.1.3
+      run: pipx install poetry==${{ inputs.poetry_version }}
       shell: bash
+
     - name: Set up Python 🐍
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ inputs.python_version }}
         cache: poetry
+        cache-dependency-path: poetry.lock
+
+    - name: Set Poetry environment
+      run: poetry env use ${{ inputs.python_version }}
+      shell: bash
 
     - name: Default shell
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 on:
   push:
     branches:
-      - '*'
+      - master
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,14 @@ jobs:
     strategy:
       matrix:
         task: ["fmt", "lint"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: ./.github/actions/common-setup
+        with:
+          python_version: ${{ matrix.python-version }}
 
       - name: check code
         run: poetry run poe ${{ matrix.task }}
@@ -28,11 +31,16 @@ jobs:
   build:
     needs: code_checks
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: ./.github/actions/common-setup
+        with:
+          python_version: ${{ matrix.python-version }}
 
       - name: Build 🔨
         run: poetry build
@@ -40,13 +48,16 @@ jobs:
   build_windows:
     needs: code_checks
     runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: ./.github/actions/common-setup
         with:
-          python_version: 3.13
+          python_version: ${{ matrix.python-version }}
           poetry_version: 2.1.3
 
       - name: Add entrypoint to bypass issue with relative imports in PyInstaller
@@ -72,6 +83,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -83,6 +95,8 @@ jobs:
           submodules: true
 
       - uses: ./.github/actions/common-setup
+        with:
+          python_version: ${{ matrix.python-version }}
 
       - name: Run tests
         run: poetry run poe test_e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - '*'
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         task: ["fmt", "lint"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -50,7 +50,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -83,7 +83,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         shell: bash
 
       - name: Upload Windows release artefact
-        if: ${{ matrix.python-version }} == 3.13
+        if: ${{ matrix.python-version == 3.13 }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: checksec.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
         shell: bash
 
   test:
-    needs: build
+    needs: ['build', 'build_windows']
+    
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         shell: bash
 
       - name: Upload Windows release artefact
+        if: ${{ matrix.python-version }} == 3.13
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: checksec.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: ./.github/actions/common-setup
         with:
           python_version: 3.13
+          poetry_version: 2.1.3
 
       - name: Add entrypoint to bypass issue with relative imports in PyInstaller
         run: powershell -Command 'Invoke-WebRequest https://gist.githubusercontent.com/Wenzel/e38d227d94f16e026b3aed03ea6a6661/raw/383ec56d62c58e444f6c5962ee6940a5c583d341/stub.py -OutFile stub.py'


### PR DESCRIPTION
Hi !

This PR is providing the following changes:

- A rework of the caching mechanism to make it work also on Windows build and use the native setup-python action cache mechanism
- Enhance the test and build steps to support all stable versions of Python currently supported by the app

Here is the Gemini-generated highlights:

* **CI Environment Setup**: The CI setup action (`common-setup`) has been updated to use `pipx` for Poetry installation, replacing the previously used `abatilo/actions-poetry` action. This change streamlines the Poetry setup process.
* **Dependency Caching Optimization**: Dependency caching for Poetry projects now leverages the built-in `cache: poetry` feature of `actions/setup-python`. This eliminates the need for a separate `actions/cache` step dedicated to Poetry dependencies, simplifying the workflow and potentially improving cache hit rates.
* **Explicit Poetry Environment Management**: An explicit step `poetry env use ${{ inputs.python_version }}` has been added. This ensures that Poetry correctly identifies and utilizes the specified Python version for the project's virtual environment, enhancing consistency across CI runs.
* **Configurable Poetry Version**: A new input `poetry_version` has been introduced to the `common-setup` action, allowing the specific version of Poetry to be installed to be configured externally. The default version is set to `2.1.3`.

