### PR TITLE
Add NA values for NX and fortify_source

### DIFF
--- a/checksec/binary.py
+++ b/checksec/binary.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Union
 
@@ -11,6 +12,12 @@ if TYPE_CHECKING:
     from .pe import PEChecksecData
 
 
+class NX(Enum):
+    No = 1
+    Yes = 2
+    NA = 3
+
+
 class BinarySecurity(ABC):
     def __init__(self, bin_path: Path):
         self.bin = lief.parse(str(bin_path))
@@ -18,13 +25,14 @@ class BinarySecurity(ABC):
             raise ErrorParsingFailed(bin_path)
 
     @property
-    def has_nx(self) -> bool:
+    def has_nx(self) -> NX:
         # Handle ELF binary with no program segments (e.g., Kernel modules)
-        # In this case, return True
         if isinstance(self.bin, lief.ELF.Binary) and len(self.bin.segments) == 0:
-            return True
+            return NX.NA
+        elif self.bin.has_nx:
+            return NX.Yes
         else:
-            return self.bin.has_nx
+            return NX.No
 
     @property
     def checksec_state(self) -> Union["ELFChecksecData", "PEChecksecData"]:

--- a/checksec/elf.py
+++ b/checksec/elf.py
@@ -66,6 +66,12 @@ def is_elf(filepath: Path) -> bool:
     return lief.is_elf(str(filepath))
 
 
+class FortifySource(Enum):
+    No = 1
+    Yes = 2
+    NA = 3
+
+
 class RelroType(Enum):
     No = 1
     Partial = 2
@@ -215,7 +221,7 @@ class ELFSecurity(BinarySecurity):
 
     @property
     def checksec_state(self) -> ELFChecksecData:
-        fortify_source = None
+        fortify_source = FortifySource.NA
         fortified_count = None
         fortifiable_count = None
         score = None
@@ -232,7 +238,12 @@ class ELFSecurity(BinarySecurity):
                 else:
                     score = (fortified_count * 100) / fortifiable_count
                     score = round(score)
-            fortify_source = True if fortified_count != 0 or fortifiable_count == 0 else False
+            if fortified_count != 0:
+                fortify_source = FortifySource.Yes
+            elif fortifiable_count == 0:
+                fortify_source = FortifySource.NA
+            else:
+                fortify_source = FortifySource.No
         return ELFChecksecData(
             relro=self.relro,
             canary=self.has_canary,

--- a/checksec/output.py
+++ b/checksec/output.py
@@ -9,7 +9,8 @@ from rich.console import Console
 from rich.progress import BarColumn, Progress, TextColumn
 from rich.table import Table
 
-from checksec.elf import ELFChecksecData, PIEType, RelroType
+from checksec.binary import NX
+from checksec.elf import ELFChecksecData, FortifySource, PIEType, RelroType
 from checksec.pe import PEChecksecData
 
 MACHINE_TYPES = Header.MACHINE_TYPES
@@ -145,10 +146,11 @@ class RichOutput(AbstractChecksecOutput):
         if isinstance(checksec, ELFChecksecData):
             row_res: List[str] = []
             # display results
-            if not checksec.nx:
-                nx_res = "[red]No"
+            nx = checksec.nx
+            if nx == NX.No:
+                nx_res = f"[red]{nx.name}"
             else:
-                nx_res = "[green]Yes"
+                nx_res = f"[green]{nx.name}"
             row_res.append(nx_res)
 
             pie = checksec.pie
@@ -197,13 +199,14 @@ class RichOutput(AbstractChecksecOutput):
 
             # fortify results depend on having a Libc available
             if self._libc_detected:
-                fortified_count = checksec.fortified
-                if checksec.fortify_source:
-                    fortify_source_res = "[green]Yes"
+                fortify_source = checksec.fortify_source
+                if fortify_source == FortifySource.No:
+                    fortify_source_res = f"[red]{fortify_source.name}"
                 else:
-                    fortify_source_res = "[red]No"
+                    fortify_source_res = f"[green]{fortify_source.name}"
                 row_res.append(fortify_source_res)
 
+                fortified_count = checksec.fortified
                 if fortified_count == 0:
                     fortified_res = "[red]No"
                 else:
@@ -227,10 +230,11 @@ class RichOutput(AbstractChecksecOutput):
 
             self.table_elf.add_row(str(filepath), *row_res)
         elif isinstance(checksec, PEChecksecData):
-            if not checksec.nx:
-                nx_res = "[red]No"
+            nx = checksec.nx
+            if nx == NX.No:
+                nx_res = f"[red]{nx.name}"
             else:
-                nx_res = "[green]Yes"
+                nx_res = f"[green]{nx.name}"
 
             if not checksec.canary:
                 canary_res = "[red]No"
@@ -340,19 +344,19 @@ class JSONOutput(AbstractChecksecOutput):
             self.data[str(filepath.resolve())] = {
                 "relro": checksec.relro.name,
                 "canary": checksec.canary,
-                "nx": checksec.nx,
+                "nx": checksec.nx.name,
                 "pie": checksec.pie.name,
                 "rpath": checksec.rpath,
                 "runpath": checksec.runpath,
                 "symbols": checksec.symbols,
-                "fortify_source": checksec.fortify_source,
+                "fortify_source": checksec.fortify_source.name,
                 "fortified": checksec.fortified,
                 "fortify-able": checksec.fortifiable,
                 "fortify_score": checksec.fortify_score,
             }
         elif isinstance(checksec, PEChecksecData):
             self.data[str(filepath.resolve())] = {
-                "nx": checksec.nx,
+                "nx": checksec.nx.name,
                 "canary": checksec.canary,
                 "aslr": checksec.aslr,
                 "dynamic_base": checksec.dynamic_base,

--- a/tests/e2e/test_e2e_elf.py
+++ b/tests/e2e/test_e2e_elf.py
@@ -4,20 +4,37 @@ from pathlib import Path
 
 import pytest
 
-from checksec.elf import PIEType, RelroType
+from checksec.binary import NX
+from checksec.elf import FortifySource, PIEType, RelroType
 from tests.conftest import run_checksec
 
 ELF_BINARIES = Path(__file__).parent.parent / "binaries" / "elf"
 
 
 @pytest.mark.parametrize("is_enabled", [False, True])
-@pytest.mark.parametrize("prop", ["nx", "canary", "rpath", "runpath", "symbols", "fortify_source"])
+@pytest.mark.parametrize("prop", ["canary", "rpath", "runpath", "symbols"])
 def test_bool_prop(prop: str, is_enabled: bool):
     """Test that boolean prop is disabled/enabled"""
     libc_path = ELF_BINARIES / "libc-2.27.so"
     bin_path = ELF_BINARIES / f"{prop}_{'enabled' if is_enabled else 'disabled'}"
     chk_data = run_checksec(bin_path, libc_path)
     assert chk_data[str(bin_path)][prop] == is_enabled
+
+
+@pytest.mark.parametrize("nx", list(NX))
+def test_nx(nx: NX):
+    """Test that nx is No/Yes/NA"""
+    bin_path = ELF_BINARIES / f"nx_{nx.name.lower()}"
+    chk_data = run_checksec(bin_path)
+    assert chk_data[str(bin_path)]["nx"] == nx.name
+
+
+@pytest.mark.parametrize("fortify_source", list(FortifySource))
+def test_fortify_source(fortify_source: FortifySource):
+    """Test that fortify_source is No/Yes/NA"""
+    bin_path = ELF_BINARIES / f"fortify_source_{fortify_source.name.lower()}"
+    chk_data = run_checksec(bin_path)
+    assert chk_data[str(bin_path)]["fortify_source"] == fortify_source.name
 
 
 @pytest.mark.parametrize("relro_type", list(RelroType))

--- a/tests/e2e/test_e2e_pe.py
+++ b/tests/e2e/test_e2e_pe.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from checksec.binary import NX
 from tests.conftest import run_checksec
 
 PE_BINARIES = Path(__file__).parent.parent / "binaries" / "pe"
@@ -13,7 +14,6 @@ PE_BINARIES = Path(__file__).parent.parent / "binaries" / "pe"
 @pytest.mark.parametrize(
     "prop",
     [
-        "nx",
         "canary",
         "dynamic_base",
         "aslr",
@@ -30,3 +30,13 @@ def test_bool_prop(prop: str, is_enabled: bool):
     bin_path = PE_BINARIES / f"{prop}_{'enabled' if is_enabled else 'disabled'}.exe"
     chk_data = run_checksec(bin_path)
     assert chk_data[str(bin_path)][prop] == is_enabled
+
+
+@pytest.mark.parametrize("nx", list(NX))
+def test_nx(nx: NX):
+    """Test that nx is No/Yes"""
+    # NA not possible for PE (only for ELF)
+    if nx != NX.NA:
+        bin_path = PE_BINARIES / f"nx_{'enabled' if nx == NX.Yes else 'disabled'}.exe"
+        chk_data = run_checksec(bin_path)
+        assert chk_data[str(bin_path)]["nx"] == nx.name


### PR DESCRIPTION
Return NA instead of True for kernel module and NA instead of True when 0 fortifiable functions were detected in the binary. This will avoid to return incorrect values for binaries compiled with a toolchain that does not support fortify_source (e.g. musl) on a processor that does not support NX (e.g. mips)